### PR TITLE
fix: 修复滚仓模式下自动售卖时出现ocr检测失败，导致无法继续运行

### DIFF
--- a/src/services/detector.py
+++ b/src/services/detector.py
@@ -236,13 +236,13 @@ class RollingModeDetector(PriceDetector):
         binarize = False
         if self.screen_capture.width == 1920:
             font = "g"
-        res = self._detect_area("expected_revenue_area", binarize=binarize, font=font)
+        res = self._detect_area("expected_revenue_area", binarize=binarize, font=font,abnormal_value=0)
         # 检测器会把售价边上的问号当成7，所以这里特殊处理一下... TODO: 以后再修
         return int((res - 7) / 10) if res % 10 == 7 else res
 
     def detect_total_sell_price_area(self) -> int:
         """检测当前售卖总价"""
-        return self._detect_area("total_sell_price_area", font="w", thresh=60)
+        return self._detect_area("total_sell_price_area", font="w", thresh=60,abnormal_value=0)
 
     def _detect_area(self, template, abnormal_value=100, binarize=True, font="", thresh=127) -> int:
         """检测模板的区域, 并返回数值"""

--- a/src/services/trading_modes.py
+++ b/src/services/trading_modes.py
@@ -257,7 +257,9 @@ class RollingTradingMode(ITradingMode):
             current_price = 0
             for i in range(5):
                 # 检测价格
-                current_price = self.detector.detect_price()
+                current_price = self.detector.detect_price(abnormal_value=0)
+              # 第一次检测价格时不需要太精确，如价格差异太大，可以开启二次检测
+                
                 if current_price > min_price:
                     break
                 print(f"价格小于异常价格，重新检测({i}/5)")


### PR DESCRIPTION
问题背景：  
滚仓模式下自动售卖时出现ocr检测失败，导致程序无法继续运行

修复方案：  
将部分方法中的abnormal_value默认值设置为0
