### PR TITLE
fix: 修复_detect_value方法调用时识别不准确导致出现ocr检测失败 & refactor: 重构快速售卖时的价格设置逻辑

### DIFF
--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -1,35 +1,39 @@
-ideal_price: 550
+ideal_price: 0
 key_mode: false
-max_price: 748
+max_price: 0
 rolling_loop_interval: 50
 hoarding_loop_interval: 150
 item_type: 0
-use_balance_calculation: true
-trading_mode: 0
+use_balance_calculation: false
+trading_mode: 1
 rolling_option: 0
 rolling_options:
-  - buy_price: 478
+  - buy_price: 520
     min_buy_price: 300
     buy_count: 4980
-    fast_sell_threshold: 200000
-  - buy_price: 3400
-    min_buy_price: 1500
+    fast_sell_threshold: 0
+    min_sell_price: 0
+  - buy_price: 450
+    min_buy_price: 270
     buy_count: 4980
-    fast_sell_threshold: 5000
-  - buy_price: 5200
-    min_buy_price: 2500
+    fast_sell_threshold: 0
+    min_sell_price: 0
+  - buy_price: 450
+    min_buy_price: 270
     buy_count: 4980
-    fast_sell_threshold: 15000
-  - buy_price: 1800
-    min_buy_price: 1200
-    buy_count: 4980
-    fast_sell_threshold: 20000
+    fast_sell_threshold: 0
+    min_sell_price: 0
+  - buy_price: 1700
+    min_buy_price: 700
+    buy_count: 1740
+    fast_sell_threshold: 0
+    min_sell_price: 0
 screen_width: 2560
 screen_height: 1440
 auto_sell: true
 fast_sell: true
 log_level: INFO
 second_detect: false
-switch_to_battlefield: true
-switch_to_battlefield_count: 400
+switch_to_battlefield: false
+switch_to_battlefield_count: 300
 min_sell_price: 528

--- a/src/config/coordinates.py
+++ b/src/config/coordinates.py
@@ -53,6 +53,8 @@ class CoordinateConfig:
             # 物品右键点击后鼠标位置到出售按钮位置的偏移量
             "item_sell_offset": [77 / 2560, 147 / 1440],
             "sell_button": [1965 / 2560, 939 / 1440],
+            # 快速售卖指定点击位置坐标
+            "btn_quickSell_area": [1965 / 2560, 939 / 1440],
             "sell_return_button": [1280 / 2560, 1258 / 1440],
             # 当前最小价格的柱子所在位置
             "min_sell_price_button": [655 / 2560, 904 / 1440],
@@ -60,6 +62,8 @@ class CoordinateConfig:
             "min_sell_price_area": [615 / 2560, 986 / 1440, 710 / 2560, 1016 / 1440],
             # 用于检测当前第二小价格的区域(第二根柱子)
             "second_min_sell_price_area": [777 / 2560, 986 / 1440, 886 / 2560, 1013 / 1440],
+            # 倒数第二根柱子指定点击位置
+            "fast_sell_price_button": [1165 / 2560, 700 / 1440],
             # 检测最小价格数量的区域
             "min_sell_price_count_area": [575 / 2560, 500 / 1440, 720 / 2560, 985 / 1440],
             "sell_count_area": [1570 / 2560, 680 / 1440, 1760 / 2560, 710 / 1440],

--- a/src/config/trading_config.py
+++ b/src/config/trading_config.py
@@ -39,6 +39,7 @@ class TradingConfig:
     second_detect: bool = False
     switch_to_battlefield: bool = False
     switch_to_battlefield_count: int = 300
+    min_sell_price: int = 0
 
     def __post_init__(self):
         """验证配置参数"""

--- a/src/services/detector.py
+++ b/src/services/detector.py
@@ -38,7 +38,7 @@ class PriceDetector(IPriceDetector):
     def _detect_value(
         self,
         coords: List[float],
-        abnormal_value=100,
+        # abnormal_value=100,
         binarize=True,
         font="",
         thresh=127,
@@ -48,9 +48,9 @@ class PriceDetector(IPriceDetector):
             screenshot = self.screen_capture.capture_region(coords)
             value = self._extract_number(screenshot, binarize, font, thresh)
             if value is not None:
-                if value < abnormal_value:  # 仅对价格进行异常过滤
-                    print("ocr检测({value})异常，跳过检测")
-                    continue
+                # if value < abnormal_value:  # 仅对价格进行异常过滤
+                #     print("ocr检测({value})异常，跳过检测")
+                #     continue
                 print("detected:", value)
                 return value
 
@@ -73,7 +73,7 @@ class PriceDetector(IPriceDetector):
         """检测当前哈夫币余额"""
         try:
             coords = self.coordinates["balance_detection"]
-            return self._detect_value(coords, 0, font="w", thresh=100)
+            return self._detect_value(coords, font="w", thresh=100)
         except Exception as e:
             raise BalanceDetectionException(f"余额检测异常: {e}") from e
 
@@ -222,7 +222,7 @@ class RollingModeDetector(PriceDetector):
         font = "w"
         if self.screen_capture.width == 1920:
             font = "c"
-        return self._detect_area("min_sell_price_count_area", 0, binarize=False, font=font)
+        return self._detect_area("min_sell_price_count_area",  binarize=False, font=font)
 
     def detect_expected_revenue(self) -> int:
         """检测当前售卖的期望收益"""
@@ -238,12 +238,12 @@ class RollingModeDetector(PriceDetector):
         """检测当前售卖总价"""
         return self._detect_area("total_sell_price_area", font="w", thresh=60)
 
-    def _detect_area(self, template, abnormal_value=100, binarize=True, font="", thresh=127) -> int:
+    def _detect_area(self, template, binarize=True, font="", thresh=127) -> int:
         """检测模板的区域, 并返回数值"""
         try:
             coords = self.coordinates["rolling_mode"][template]
             return self._detect_value(
-                coords, abnormal_value=abnormal_value, binarize=binarize, font=font, thresh=thresh
+                coords, binarize=binarize, font=font, thresh=thresh
             )
         except Exception as e:
             raise PriceDetectionException(f"价格检测异常: {e}") from e


### PR DESCRIPTION
1.修复_detect_value方法调用时识别不准确导致出现ocr检测失败，删除abnormal_value参数
2.重构快速售卖时的价格设置逻辑，设置价格时先将价格设置成最小值1，然后鼠标点中一个指定位置后价格会变为该物品的最低价，此时点击倒数第二根价格柱子即可获得当前可以快速售卖的最高价格。
